### PR TITLE
include credentials in fetch, because we need the cors headers

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -8,6 +8,7 @@ export function getResource(headers, host, endpointUrl) {
   return fetch(`${host}/${endpointUrl}/`, {
     headers,
     mode: 'cors',
+    credentials: 'include',
   })
     .then(handleErrors)
     .then(response => response.json());


### PR DESCRIPTION
This is why agendas do not load on localhost with ```npm run dev```