### PR TITLE
Move Recaptcha to form confirmation.

### DIFF
--- a/src/actions/Form.js
+++ b/src/actions/Form.js
@@ -7,6 +7,7 @@ export const FORM_RESET = 'FORM_RESET';
 export const FORM_SAVE = 'FORM_SAVE';
 export const CAPTCHA_VERIFIED = 'CAPTCHA_VERIFIED';
 export const FORM_SUBMITTED = 'FORM_SUBMITTED';
+export const TOKEN_SUBMIT = 'TOKEN_SUBMIT';
 export const FORM_EDITING = 'FORM_EDITING';
 export const FORM_COMPLETE = 'FORM_COMPLETE';
 
@@ -92,5 +93,6 @@ export const submitForm = token => (dispatch, getState) => {
 };
 
 export const verifiedCaptcha = token => (dispatch) => {
-  dispatch(submitForm(token));
+  // dispatch(submitForm(token));
+  dispatch(submitToken(token));
 };

--- a/src/actions/Form.js
+++ b/src/actions/Form.js
@@ -35,6 +35,11 @@ export const editingForm = value => ({
   payload: value,
 });
 
+export const submitToken = value => ({
+  type: TOKEN_SUBMIT,
+  payload: value,
+})
+
 export const formSubmitted = success => ({
   type: FORM_SUBMITTED,
   payload: success,

--- a/src/actions/Form.js
+++ b/src/actions/Form.js
@@ -93,6 +93,5 @@ export const submitForm = token => (dispatch, getState) => {
 };
 
 export const verifiedCaptcha = token => (dispatch) => {
-  // dispatch(submitForm(token));
   dispatch(submitToken(token));
 };

--- a/src/component/ConfirmFormContentComponent.jsx
+++ b/src/component/ConfirmFormContentComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Recaptcha from './Recaptcha.jsx';
 import { Segment, Container, Header, Button } from 'semantic-ui-react';
 import './ConfirmFormContent.scss';
 
@@ -43,6 +44,7 @@ class ConfirmFormContentComponent extends React.Component {
               {'By submitting this form, you consent to entering the above data, including your email address, as a matter of Public Record and you certify that you are not knowingly submitting false information.'}
             </Header>
           </Segment>
+          <Recaptcha display={this.props.firstName !== ''} />
           <Segment textAlign="center">
             <Button color="green" onClick={() => { this.props.saveForm(this.props.complete); }}>
               <Header as="h1" style={{ color: 'white' }}>SUBMIT</Header>

--- a/src/component/ConfirmFormContentComponent.jsx
+++ b/src/component/ConfirmFormContentComponent.jsx
@@ -44,9 +44,9 @@ class ConfirmFormContentComponent extends React.Component {
               {'By submitting this form, you consent to entering the above data, including your email address, as a matter of Public Record and you certify that you are not knowingly submitting false information.'}
             </Header>
           </Segment>
-          <Recaptcha /*display={this.props.firstName !== ''}*/ onVerify={this.props.onVerify} />
+          <Recaptcha onVerify={this.props.onVerify} />
           <Segment textAlign="center">
-            <Button color="green" disabled={this.props.token === null} onClick={() => { { this.props.submitForm(this.props.token) } /*{ this.props.saveForm(this.props.complete); }*/ }}>
+            <Button color="green" disabled={this.props.token === null} onClick={() => this.props.submitForm(this.props.token)}>
               <Header as="h1" style={{ color: 'white' }}>SUBMIT</Header>
             </Button>
           </Segment>

--- a/src/component/ConfirmFormContentComponent.jsx
+++ b/src/component/ConfirmFormContentComponent.jsx
@@ -46,7 +46,7 @@ class ConfirmFormContentComponent extends React.Component {
           </Segment>
           <Recaptcha display={this.props.firstName !== ''} onVerify={this.props.onVerify} />
           <Segment textAlign="center">
-            <Button color="green" disabled={this.props.token === null} onClick={() => { this.props.saveForm(this.props.complete); }}>
+            <Button color="green" disabled={this.props.token === null} onClick={() => { { this.props.submitForm(this.props.token) } /*{ this.props.saveForm(this.props.complete); }*/ }}>
               <Header as="h1" style={{ color: 'white' }}>SUBMIT</Header>
             </Button>
           </Segment>

--- a/src/component/ConfirmFormContentComponent.jsx
+++ b/src/component/ConfirmFormContentComponent.jsx
@@ -44,9 +44,9 @@ class ConfirmFormContentComponent extends React.Component {
               {'By submitting this form, you consent to entering the above data, including your email address, as a matter of Public Record and you certify that you are not knowingly submitting false information.'}
             </Header>
           </Segment>
-          <Recaptcha display={this.props.firstName !== ''} />
+          <Recaptcha display={this.props.firstName !== ''} onVerify={this.props.onVerify} />
           <Segment textAlign="center">
-            <Button color="green" onClick={() => { this.props.saveForm(this.props.complete); }}>
+            <Button color="green" disabled={this.props.token === null} onClick={() => { this.props.saveForm(this.props.complete); }}>
               <Header as="h1" style={{ color: 'white' }}>SUBMIT</Header>
             </Button>
           </Segment>

--- a/src/component/ConfirmFormContentComponent.jsx
+++ b/src/component/ConfirmFormContentComponent.jsx
@@ -46,7 +46,7 @@ class ConfirmFormContentComponent extends React.Component {
           </Segment>
           <Recaptcha onVerify={this.props.onVerify} />
           <Segment textAlign="center">
-            <Button color="green" disabled={this.props.token === null} onClick={() => this.props.submitForm(this.props.token)}>
+            <Button color="green" disabled={this.props.token === null} onClick={() => this.props.handleSubmit(this.props.complete)}>
               <Header as="h1" style={{ color: 'white' }}>SUBMIT</Header>
             </Button>
           </Segment>

--- a/src/component/ConfirmFormContentComponent.jsx
+++ b/src/component/ConfirmFormContentComponent.jsx
@@ -44,7 +44,7 @@ class ConfirmFormContentComponent extends React.Component {
               {'By submitting this form, you consent to entering the above data, including your email address, as a matter of Public Record and you certify that you are not knowingly submitting false information.'}
             </Header>
           </Segment>
-          <Recaptcha display={this.props.firstName !== ''} onVerify={this.props.onVerify} />
+          <Recaptcha /*display={this.props.firstName !== ''}*/ onVerify={this.props.onVerify} />
           <Segment textAlign="center">
             <Button color="green" disabled={this.props.token === null} onClick={() => { { this.props.submitForm(this.props.token) } /*{ this.props.saveForm(this.props.complete); }*/ }}>
               <Header as="h1" style={{ color: 'white' }}>SUBMIT</Header>

--- a/src/component/Recaptcha.jsx
+++ b/src/component/Recaptcha.jsx
@@ -11,29 +11,29 @@ class Recaptcha extends Component {
     };
   }
   render() {
-    if (this.props.display) {
-      return (
-        <Segment>
-          <div style={{
-            position: 'relative',
-            display: this.props.firstName !== '' ? 'flex' : 'none',
-            minHeight: '63vh',
-            flexDirection: 'column',
-            alignItems: 'center',
-            alignContent: 'center',
-          }}
-          >
-            <Header as="h3">For unregistered users we need to make sure you are a human.</Header>
-            <ReCAPTCHA
-              ref="recaptcha"
-              sitekey="6Lex02wUAAAAAI6g5DnS3iIMMqhQSXReUINtVi94"
-              onChange={this.props.onVerify}
-            />
-          </div>
-        </Segment>
-      );
-    }
-    return <div></div>;
+    // if (this.props.display) {
+    return (
+      <Segment>
+        <div style={{
+          position: 'relative',
+          // display: this.props.firstName !== '' ? 'flex' : 'none',
+          minHeight: '63vh',
+          flexDirection: 'column',
+          alignItems: 'center',
+          alignContent: 'center',
+        }}
+        >
+          <Header as="h3">For unregistered users we need to make sure you are a human.</Header>
+          <ReCAPTCHA
+            ref="recaptcha"
+            sitekey="6Lex02wUAAAAAI6g5DnS3iIMMqhQSXReUINtVi94"
+            onChange={this.props.onVerify}
+          />
+        </div>
+      </Segment>
+    );
+    // }
+    // return <div></div>;
   }
 }
 export default Recaptcha;

--- a/src/component/Recaptcha.jsx
+++ b/src/component/Recaptcha.jsx
@@ -17,7 +17,6 @@ class Recaptcha extends Component {
         <div style={{
           position: 'relative',
           // display: this.props.firstName !== '' ? 'flex' : 'none',
-          minHeight: '63vh',
           flexDirection: 'column',
           alignItems: 'center',
           alignContent: 'center',

--- a/src/component/Recaptcha.jsx
+++ b/src/component/Recaptcha.jsx
@@ -11,12 +11,10 @@ class Recaptcha extends Component {
     };
   }
   render() {
-    // if (this.props.display) {
     return (
       <Segment>
         <div style={{
           position: 'relative',
-          // display: this.props.firstName !== '' ? 'flex' : 'none',
           flexDirection: 'column',
           alignItems: 'center',
           alignContent: 'center',
@@ -31,8 +29,6 @@ class Recaptcha extends Component {
         </div>
       </Segment>
     );
-    // }
-    // return <div></div>;
   }
 }
 export default Recaptcha;

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -103,6 +103,7 @@ class FormContainer extends Component {
               Title={this.props.Title}
               content={this.props.content}
               complete={this.props.complete}
+              submitForm={this.props.submitForm}
               saveForm={this.props.saveForm}
               resetForm={this.props.resetForm}
               editingForm={this.props.editingForm}

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -107,6 +107,8 @@ class FormContainer extends Component {
               resetForm={this.props.resetForm}
               editingForm={this.props.editingForm}
               scrollToAppTop={this.scrollToAppTop}
+              token={this.props.token}
+              onVerify={this.onVerify}
             />
           </div>
         </div>

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -6,7 +6,6 @@ import { setHours, setMinutes } from 'date-fns';
 import { verifiedCaptcha, resetForm, saveForm, editingForm, submitForm, completeForm } from '../actions/Form';
 import ConfirmFormContentComponent from '../component/ConfirmFormContentComponent.jsx';
 import PositionFormFinalStep from '../component/PositionFormFinalStep.jsx';
-import Recaptcha from '../component/Recaptcha.jsx';
 
 class FormContainer extends Component {
   constructor(props) {
@@ -102,14 +101,12 @@ class FormContainer extends Component {
               Title={this.props.Title}
               content={this.props.content}
               complete={this.props.complete}
-              firstName={this.props.firstName}
               onVerify={this.onVerify}
               submitForm={this.props.submitForm}
-              saveForm={this.props.saveForm}
               resetForm={this.props.resetForm}
               editingForm={this.props.editingForm}
               scrollToAppTop={this.scrollToAppTop}
-              token={this.props.token}
+              token={this.props.token} // captcha token
             />
           </div>
         </div>

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -44,7 +44,6 @@ class FormContainer extends Component {
 
   handleSubmit(values) {
     this.props.saveForm(values);
-    debugger;
     this.props.submitForm(this.props.token);
   }
 

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -39,7 +39,6 @@ class FormContainer extends Component {
   }
 
   onVerify(evt) { // only executes on success
-    this.props.saveForm(this.props.complete);
     this.props.verifiedCaptcha(evt);
   }
 

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -17,6 +17,7 @@ class FormContainer extends Component {
     this.onVerify = this.onVerify.bind(this);
     this.returnToItem = this.returnToItem.bind(this);
     this.scrollToAppTop = this.scrollToAppTop.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
   componentWillMount() {
     if (this.props.submitted) {
@@ -41,8 +42,9 @@ class FormContainer extends Component {
     this.props.verifiedCaptcha(evt);
   }
 
-  handleSubmit(evt) {
-    this.props.saveForm(this.props.complete);
+  handleSubmit(values) {
+    this.props.saveForm(values);
+    debugger;
     this.props.submitForm(this.props.token);
   }
 
@@ -107,7 +109,7 @@ class FormContainer extends Component {
               content={this.props.content}
               complete={this.props.complete}
               onVerify={this.onVerify}
-              submitForm={this.props.submitForm}
+              handleSubmit={this.handleSubmit}
               resetForm={this.props.resetForm}
               editingForm={this.props.editingForm}
               scrollToAppTop={this.scrollToAppTop}

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -39,6 +39,7 @@ class FormContainer extends Component {
   }
 
   onVerify(evt) { // only executes on success
+    this.props.saveForm(this.props.complete);
     this.props.verifiedCaptcha(evt);
   }
 

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -87,7 +87,6 @@ class FormContainer extends Component {
     } else if (!this.props.submitted) {
       return (
         <div style={{ display: 'flex', minHeight: '63vh', flexDirection: 'column' }}>
-          <Recaptcha display={this.props.firstName !== ''} onVerify={this.onVerify} />
           <div
             style={{
               position: 'relative',

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -103,13 +103,14 @@ class FormContainer extends Component {
               Title={this.props.Title}
               content={this.props.content}
               complete={this.props.complete}
+              firstName={this.props.firstName}
+              onVerify={this.onVerify}
               submitForm={this.props.submitForm}
               saveForm={this.props.saveForm}
               resetForm={this.props.resetForm}
               editingForm={this.props.editingForm}
               scrollToAppTop={this.scrollToAppTop}
               token={this.props.token}
-              onVerify={this.onVerify}
             />
           </div>
         </div>

--- a/src/container/FormContainer.jsx
+++ b/src/container/FormContainer.jsx
@@ -41,6 +41,11 @@ class FormContainer extends Component {
     this.props.verifiedCaptcha(evt);
   }
 
+  handleSubmit(evt) {
+    this.props.saveForm(this.props.complete);
+    this.props.submitForm(this.props.token);
+  }
+
   returnToItem(id) {
     this.props.resetForm();
     this.props.history.push(`/feed/${id}`);

--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -5,6 +5,7 @@ import {
   FORM_SUBMITTED,
   CAPTCHA_VERIFIED,
   FORM_EDITING,
+  TOKEN_SUBMIT,
   FORM_COMPLETE,
 } from '../actions/Form';
 
@@ -37,45 +38,47 @@ const defaultFormState = {
 
 export default function (state = defaultFormState, action) {
   switch (action.type) {
-  case AGENDA_ITEM_RECEIVED:
-    return Object.assign({}, state, {
-      Title: action.payload.Title,
-      Recommendations: action.payload.Recommendations,
-      Summary: action.payload.Summary,
-      Id: action.payload.Id,
-      Pro: action.payload.Pro,
-      Committee: action.payload.Committee,
-      AgendaItemId: action.payload.AgendaItemId,
-    });
-  case FORM_SAVE:
-    return Object.assign({}, state, {
-      committee: action.payload.committee,
-      content: action.payload.content,
-      email: action.payload.email,
-      firstName: action.payload.firstName,
-      lastName: action.payload.lastName,
-      zipcode: action.payload.zipcode,
-      businessOwner: action.payload.businessOwner,
-      homeOwner: action.payload.homeOwner,
-      resident: action.payload.resident,
-      works: action.payload.works,
-      school: action.payload.school,
-      childSchool: action.payload.childSchool,
-      editing: false,
-    });
-  case FORM_EDITING:
-    return Object.assign({}, state, { editing: action.payload });
-  case FORM_SUBMITTED:
-    return Object.assign({}, defaultFormState, { submitted: true });
-  case FORM_COMPLETE:
-    return Object.assign({}, state, { complete: action.payload, editing: false });
-  case FORM_RESET:
-    return defaultFormState;
-  case CAPTCHA_VERIFIED:
-    return Object.assign({}, state, {
-      token: action.payload,
-    });
-  default:
-    return state;
+    case AGENDA_ITEM_RECEIVED:
+      return Object.assign({}, state, {
+        Title: action.payload.Title,
+        Recommendations: action.payload.Recommendations,
+        Summary: action.payload.Summary,
+        Id: action.payload.Id,
+        Pro: action.payload.Pro,
+        Committee: action.payload.Committee,
+        AgendaItemId: action.payload.AgendaItemId,
+      });
+    case FORM_SAVE:
+      return Object.assign({}, state, {
+        committee: action.payload.committee,
+        content: action.payload.content,
+        email: action.payload.email,
+        firstName: action.payload.firstName,
+        lastName: action.payload.lastName,
+        zipcode: action.payload.zipcode,
+        businessOwner: action.payload.businessOwner,
+        homeOwner: action.payload.homeOwner,
+        resident: action.payload.resident,
+        works: action.payload.works,
+        school: action.payload.school,
+        childSchool: action.payload.childSchool,
+        editing: false,
+      });
+    case FORM_EDITING:
+      return Object.assign({}, state, { editing: action.payload });
+    case TOKEN_SUBMIT:
+      return Object.assign({}, state, { token: payload });
+    case FORM_SUBMITTED:
+      return Object.assign({}, defaultFormState, { submitted: true });
+    case FORM_COMPLETE:
+      return Object.assign({}, state, { complete: action.payload, editing: false });
+    case FORM_RESET:
+      return defaultFormState;
+    case CAPTCHA_VERIFIED:
+      return Object.assign({}, state, {
+        token: action.payload,
+      });
+    default:
+      return state;
   }
 }

--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -67,7 +67,7 @@ export default function (state = defaultFormState, action) {
     case FORM_EDITING:
       return Object.assign({}, state, { editing: action.payload });
     case TOKEN_SUBMIT:
-      return Object.assign({}, state, { token: payload });
+      return Object.assign({}, state, { token: action.payload });
     case FORM_SUBMITTED:
       return Object.assign({}, defaultFormState, { submitted: true });
     case FORM_COMPLETE:


### PR DESCRIPTION
Recaptcha is now rendered over the submit button on the form confirmation page. 
Added action and reducer case to add the token to state when Recaptcha is checked.
Refactored `verifiedCaptcha()` action in form actions to add the token to state instead of submitting the form. 
*The `saveForm()` action is no longer dispatched in the form submission flow.