### PR TITLE
Set inner HTML when JSON contains HTML tags.

### DIFF
--- a/src/component/HowTo.jsx
+++ b/src/component/HowTo.jsx
@@ -25,7 +25,7 @@ const HowTo = props => (
         <img src="static/image/engage_howto_img1.png" />
         <p style={{ fontSize: '1em' }}>{copyText.submit_feedback.body_text_step_2}</p>
         <img src="static/image/engage_howto_img2.png" />
-        <p style={{ fontSize: '1em' }}>{copyText.submit_feedback.body_text_step_3}</p>
+        <p style={{ fontSize: '1em' }} dangerouslySetInnerHTML={ {__html: copyText.submit_feedback.body_text_step_3} }></p>
         <img src="static/image/engage_howto_img3.png" />
         <p style={{ fontSize: '1em' }}>{copyText.submit_feedback.body_text_step_4}</p>
         <img src="static/image/engage_howto_img4.png" />


### PR DESCRIPTION
It looks like HTML strings that are stored inside JSON aren't rendered correctly when interpolated JSX. If we know that a certain piece of static text will contain HTML tags, then the `dangerouslySetInnerHTML` attribute may be used to correctly render HTML along with plaintext.

Another option is the React HTML parser library.

Note, this change is only applied to a small part of the How To page. 