### PR TITLE
Fix twitter handle for Twitter share button

### DIFF
--- a/src/component/AgendaItem.jsx
+++ b/src/component/AgendaItem.jsx
@@ -211,7 +211,7 @@ class AgendaItem extends Component {
               <Card.Content textAlign="center">
                 <Header as="h3">Share this Item</Header>
                 <a className="fb-xfbml-parse-ignore" target="_blank" href={`https://www.facebook.com/sharer/sharer.php?u=${ url };src=sdkpreparse`}><Button circular color="facebook" icon="facebook"></Button></a>
-                <a target="_blank"  className="twitter-share-button" href={ `https://twitter.com/intent/tweet?text=Check%20out%20this%20new%20agenda%20item%20from%20our%20local%20government!&via=teddycrepineau&url=${ url }`}><Button circular color="twitter" icon="twitter"></Button></a>
+                <a target="_blank"  className="twitter-share-button" href={ `https://twitter.com/intent/tweet?text=Check%20out%20this%20new%20agenda%20item%20from%20our%20local%20government!&via=EngageStaMonica&url=${ url }`}><Button circular color="twitter" icon="twitter"></Button></a>
                 <a href={ `mailto:?subject=Check out this new agenda item from our city council&body=${ url }`}><Button circular color="grey" icon="mail"></Button></a>
               </Card.Content>
             </Card>


### PR DESCRIPTION
Fix twitter handle for Twitter share button @TeddyCrepineau -> @EngageStaMonica
The previous default handle on the twitter shared card was mine (used for testing). Updated to actual SM Engage twitter handle


![screen shot 2019-01-19 at 11 40 49 am](https://user-images.githubusercontent.com/13626425/51431536-1d047880-1bdf-11e9-8d08-340f32cde503.png)
