### PR TITLE
fix pdfLocation address

### DIFF
--- a/src/component/AgendaItem.jsx
+++ b/src/component/AgendaItem.jsx
@@ -288,9 +288,7 @@ class AgendaItem extends Component {
                               alignSelf: 'center',
                             }}
                             target="_blank"
-                            href={`https://backend.engage.town${
-                              this.state.agendaItem.pdfLocation
-                            }`}>
+                            href={this.state.agendaItem.pdfLocation}>
                             <Image
                               src="/static/image/pdf-icon.png"
                               style={{


### PR DESCRIPTION
remove old templating, now just uses the link text as the href content.